### PR TITLE
EoM finding in all dimensions

### DIFF
--- a/DiFfRG/include/DiFfRG/discretization/FEM/assembler/common.hh
+++ b/DiFfRG/include/DiFfRG/discretization/FEM/assembler/common.hh
@@ -19,8 +19,8 @@
 #include <tbb/tbb.h>
 
 #include <DiFfRG/common/utils.hh>
+#include <DiFfRG/discretization/common/EoM.hh>
 #include <DiFfRG/discretization/common/abstract_assembler.hh>
-#include <DiFfRG/discretization/common/utils.hh>
 #include <DiFfRG/discretization/data/data_output.hh>
 
 namespace DiFfRG

--- a/DiFfRG/include/DiFfRG/discretization/FEM/assembler/ldg.hh
+++ b/DiFfRG/include/DiFfRG/discretization/FEM/assembler/ldg.hh
@@ -24,8 +24,8 @@
 
 // DiFfRG
 #include <DiFfRG/common/utils.hh>
+#include <DiFfRG/discretization/common/EoM.hh>
 #include <DiFfRG/discretization/common/abstract_assembler.hh>
-#include <DiFfRG/discretization/common/utils.hh>
 #include <DiFfRG/discretization/data/data_output.hh>
 
 namespace DiFfRG

--- a/DiFfRG/include/DiFfRG/discretization/common/EoM.hh
+++ b/DiFfRG/include/DiFfRG/discretization/common/EoM.hh
@@ -5,9 +5,14 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/numerics/fe_field_function.h>
+#include <gsl/gsl_multiroots.h>
+#include <gsl/gsl_vector.h>
+#include <gsl/gsl_vector_double.h>
+#include <sys/types.h>
 #include <tbb/parallel_for.h>
 
 // standard library
+#include <algorithm>
 #include <iterator>
 #include <mutex>
 
@@ -15,6 +20,21 @@ namespace DiFfRG
 {
   namespace internal
   {
+    template <int dim> int gsl_unwrap(const gsl_vector *gsl_x, void *params, gsl_vector *gsl_f)
+    {
+      dealii::Point<dim> x;
+      for (int i = 0; i < dim; ++i)
+        x[i] = gsl_vector_get(gsl_x, i);
+
+      auto fp = static_cast<std::function<std::array<double, dim>(const dealii::Point<dim> &)> *>(params);
+      const auto f = (*fp)(x);
+
+      for (int i = 0; i < dim; ++i)
+        gsl_vector_set(gsl_f, i, f[i]);
+
+      return GSL_SUCCESS;
+    }
+
     using namespace dealii;
     template <int dim, typename Cell>
     bool is_in_cell(const Cell &cell, const Point<dim> &point, const Mapping<dim> &mapping)
@@ -88,7 +108,7 @@ namespace DiFfRG
    * @param mapping a Mapping object associated with the solution vector.
    * @param model numerical model providing a method EoM(const VectorType &)->double which we use to find a zero
    * crossing.
-   * @param relative_tolerance the relative tolerance for the bisection method.
+   * @param EoM_abs_tol the relative tolerance for the bisection method.
    * @return Point<dim> the point where the EoM is zero.
    */
   template <typename VectorType, typename EoMFUN, typename EoMPFUN>
@@ -96,7 +116,7 @@ namespace DiFfRG
       typename dealii::DoFHandler<1>::cell_iterator &EoM_cell, const VectorType &sol,
       const dealii::DoFHandler<1> &dof_handler, const dealii::Mapping<1> &mapping, const EoMFUN &get_EoM,
       const EoMPFUN &EoM_postprocess = [](const auto &p, const auto &values) { return p; },
-      const double relative_tolerance = 1e-5, const uint max_iter = 100)
+      const double EoM_abs_tol = 1e-5, const uint max_iter = 100)
   {
     constexpr uint dim = 1;
 
@@ -154,11 +174,12 @@ namespace DiFfRG
       if (p2[0] < p1[0]) std::swap(p1, p2);
       auto p = m_EoM[0] <= p2[0] && m_EoM[0] >= p1[0] ? m_EoM : (p1 + p2) / 2.;
 
+      fe_function.vector_value(p, values);
       EoM_val = get_EoM(p, values)[0];
-      double err = std::abs(EoM_val);
+      double err = 1e100;
       uint iter = 0;
 
-      while (err > relative_tolerance) {
+      while (err > EoM_abs_tol) {
         if (EoM_val < 0.)
           p1 = p;
         else
@@ -216,7 +237,11 @@ namespace DiFfRG
         EoM_candidates.push_back(t_EoM);
       }
 
-    if (cell_candidates.size() == 0) {
+    if (cell_candidates.size() == 1) {
+      EoM_cell = cell_candidates[0];
+      EoM = EoM_candidates[0];
+      return EoM;
+    } else if (cell_candidates.size() == 0) {
       EoM_cell = GridTools::find_active_cell_around_point(dof_handler, origin);
       return origin;
     } else if (cell_candidates.size() > 1) {
@@ -234,6 +259,209 @@ namespace DiFfRG
   }
 
   /**
+   * @brief Get the EoM point for a given solution and model in 2D. This is done by first checking the origin, and then
+   * checking all cell borders in order to find a zero crossing. Then, the EoM point is found by bisection within the
+   * cell.
+   *
+   * @tparam VectorType type of the solution vector.
+   * @tparam Model type of the model.
+   * @param EoM_cell the cell where the EoM point is located, will be set by the function. Is also used as a starting
+   * point for the search.
+   * @param sol the solution vector.
+   * @param dof_handler a DoFHandler object associated with the solution vector.
+   * @param mapping a Mapping object associated with the solution vector.
+   * @param model numerical model providing a method EoM(const VectorType &)->double which we use to find a zero
+   * crossing.
+   * @param EoM_abs_tol the relative tolerance for the bisection method.
+   * @return Point<dim> the point where the EoM is zero.
+   */
+  template <int dim, typename VectorType, typename EoMFUN, typename EoMPFUN>
+  Point<dim> get_EoM_point_ND(
+      typename dealii::DoFHandler<dim>::cell_iterator &EoM_cell, const VectorType &sol,
+      const dealii::DoFHandler<dim> &dof_handler, const dealii::Mapping<dim> &mapping, const EoMFUN &get_EoM,
+      const EoMPFUN &EoM_postprocess = [](const auto &p, const auto &values) { return p; },
+      const double EoM_abs_tol = 1e-5, const uint max_iter = 100)
+  {
+    using namespace dealii;
+    using CellIterator = typename dealii::DoFHandler<dim>::cell_iterator;
+    auto EoM = Point<dim>();
+    Vector<typename VectorType::value_type> values(dof_handler.get_fe().n_components());
+
+    // We start by investigating the origin.
+    const auto origin = internal::get_origin(dof_handler, EoM_cell);
+    Functions::FEFieldFunction<dim, VectorType> fe_function(dof_handler, sol, mapping);
+    fe_function.vector_value(origin, values);
+    const double EoM_val = get_EoM(origin, values)[0];
+    if (EoM_val >= 0.) {
+      EoM = origin;
+      return EoM;
+    }
+
+    using EoMType = std::array<double, dim>;
+
+    auto check_cell = [&](const CellIterator &cell) -> bool {
+      // Obtain the values at the vertices of the cell.
+      std::array<EoMType, GeometryInfo<dim>::vertices_per_cell> EoM_vals;
+      std::array<Point<dim>, GeometryInfo<dim>::vertices_per_cell> vertices;
+      Vector<typename VectorType::value_type> values(dof_handler.get_fe().n_components());
+      Functions::FEFieldFunction<dim, VectorType> fe_function(dof_handler, sol, mapping);
+
+      fe_function.set_active_cell(cell);
+      for (uint i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i) {
+        vertices[i] = cell->vertex(i);
+        fe_function.vector_value(vertices[i], values);
+        EoM_vals[i] = get_EoM(vertices[i], values);
+      }
+
+      std::array<bool, dim> cell_has_EoM{{}};
+      // Find if the cell has an EoM point, i.e. if the values at some vertices have different signs.
+      for (uint i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (uint j = 0; j < i; ++j)
+          for (uint d = 0; d < dim; ++d)
+            cell_has_EoM[d] = cell_has_EoM[d] || (EoM_vals[i][d] * EoM_vals[j][d] < 0.);
+
+      // if all components have a potential crossing, we return true
+      return std::all_of(std::begin(cell_has_EoM), std::end(cell_has_EoM), [](bool i) { return i; });
+    };
+
+    gsl_set_error_handler_off();
+
+    auto find_EoM = [&](const CellIterator &cell, CellIterator &m_EoM_cell, Point<dim> &m_EoM,
+                        double &EoM_val) -> bool {
+      Timer time;
+      Functions::FEFieldFunction<dim, VectorType> fe_function(dof_handler, sol, mapping);
+      Vector<typename VectorType::value_type> values(dof_handler.get_fe().n_components());
+      fe_function.set_active_cell(cell);
+
+      std::array<std::array<double, 2>, dim> cell_borders;
+      for (uint d = 0; d < dim; ++d) {
+        for (uint i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i) {
+          cell_borders[d][0] = std::min(cell_borders[d][0], cell->vertex(i)[d]);
+          cell_borders[d][1] = std::max(cell_borders[d][1], cell->vertex(i)[d]);
+        }
+      }
+
+      std::function<std::array<double, dim>(const dealii::Point<dim> &)> eval_on_point =
+          [&](const Point<dim> &p) -> std::array<double, dim> {
+        // if p is outside the cell, project it to the closest border
+        Point<dim> p_proj = p;
+        /*for (uint d = 0; d < dim; ++d) {
+          if (!isfinite(p_proj[d])) {
+            p_proj = cell->center();
+          }
+          if (p_proj[d] < cell_borders[d][0])
+            p_proj[d] = cell_borders[d][0] + 1e-10 * (cell_borders[d][1] - cell_borders[d][0]);
+          else if (p_proj[d] > cell_borders[d][1])
+            p_proj[d] = cell_borders[d][1] - 1e-10 * (cell_borders[d][1] - cell_borders[d][0]);
+        }*/
+
+        fe_function.vector_value(p_proj, values);
+        return get_EoM(p_proj, values);
+      };
+
+      const auto cell_center = cell->center();
+
+      // Create GSL multiroot solver
+      const gsl_multiroot_fsolver_type *T = gsl_multiroot_fsolver_hybrids;
+      gsl_multiroot_fsolver *s = gsl_multiroot_fsolver_alloc(T, dim);
+
+      // Create GSL function
+      gsl_multiroot_function f = {&internal::gsl_unwrap<dim>, dim, &eval_on_point};
+
+      // Create initial guess
+      gsl_vector *x = gsl_vector_alloc(dim);
+      for (uint d = 0; d < dim; ++d)
+        gsl_vector_set(x, d, cell_center[d]);
+
+      // Set the solver with the function and initial guess
+      gsl_multiroot_fsolver_set(s, &f, x);
+
+      // start the iteration
+      int iter = 0;
+      int status;
+      do {
+        iter++;
+        status = gsl_multiroot_fsolver_iterate(s);
+
+        if (status) break;
+
+        status = gsl_multiroot_test_residual(s->f, EoM_abs_tol);
+      } while (status == GSL_CONTINUE && iter < 1000);
+
+      EoM_val = 0.;
+      for (uint d = 0; d < dim; ++d) {
+        m_EoM[d] = gsl_vector_get(s->x, d);
+        EoM_val += std::abs(gsl_vector_get(s->f, d));
+      }
+
+      // don't leak memory. Stupid C
+      gsl_multiroot_fsolver_free(s);
+      gsl_vector_free(x);
+
+      if (status != GSL_SUCCESS) return false;
+
+      m_EoM = EoM_postprocess(m_EoM, values);
+      m_EoM_cell = internal::is_in_cell(cell, m_EoM, mapping)
+                       ? cell
+                       : GridTools::find_active_cell_around_point(dof_handler, m_EoM);
+
+      return true;
+    };
+
+    std::vector<typename dealii::DoFHandler<dim>::cell_iterator> cell_candidates;
+    std::vector<double> value_candidates;
+    std::vector<Point<dim>> EoM_candidates;
+
+    // mutex for the EoM cell
+    std::mutex EoM_cell_mutex;
+
+    const uint n_active_cells = dof_handler.get_triangulation().n_active_cells();
+
+    // this needs to be done smarter, but for now we just iterate over all cells
+    // preferrably, we would divide the full domain into smaller subdomains and then traverse a kind of tree.
+    for (uint index = 0; index < n_active_cells; ++index) {
+      auto cell = dof_handler.begin_active();
+      std::advance(cell, index);
+      if (check_cell(cell)) {
+        Point<dim> t_EoM = cell->center();
+        CellIterator t_EoM_cell = cell;
+        double t_EoM_value = 0.;
+
+        // lock the mutex
+        std::lock_guard<std::mutex> lock(EoM_cell_mutex);
+
+        if (find_EoM(cell, t_EoM_cell, t_EoM, t_EoM_value)) {
+          EoM_cell = t_EoM_cell;
+          EoM = t_EoM;
+          return EoM;
+        }
+
+        cell_candidates.push_back(t_EoM_cell);
+        EoM_candidates.push_back(t_EoM);
+        value_candidates.push_back(std::abs(t_EoM_value));
+      }
+    }
+
+    double EoM_value = 0.;
+
+    if (cell_candidates.size() == 1) {
+      if (find_EoM(cell_candidates[0], EoM_cell, EoM, EoM_value)) return EoM;
+    } else if (cell_candidates.size() == 0) {
+      EoM_cell = GridTools::find_active_cell_around_point(dof_handler, origin);
+      return origin;
+    } else if (cell_candidates.size() > 1) {
+      // If we have more than one candidate, we choose the one with the smallest EoM value.
+      auto min_it = std::min_element(value_candidates.begin(), value_candidates.end());
+      auto min_idx = std::distance(value_candidates.begin(), min_it);
+      EoM_cell = cell_candidates[min_idx];
+      EoM = EoM_candidates[min_idx];
+      return EoM;
+    }
+
+    return EoM;
+  }
+
+  /**
    * @brief Get the EoM point for a given solution and model.
    *
    * @tparam dim dimension of the problem.
@@ -246,7 +474,7 @@ namespace DiFfRG
    * @param mapping a Mapping object associated with the solution vector.
    * @param model numerical model providing a method EoM(const VectorType &)->double which we use to find a zero
    * crossing.
-   * @param relative_tolerance the relative tolerance for the bisection method.
+   * @param EoM_abs_tol the relative tolerance for the bisection method.
    * @return Point<dim> the point where the EoM is zero.
    */
   template <int dim, typename VectorType, typename EoMFUN, typename EoMPFUN>
@@ -254,15 +482,15 @@ namespace DiFfRG
       typename dealii::DoFHandler<dim>::cell_iterator &EoM_cell, const VectorType &sol,
       const dealii::DoFHandler<dim> &dof_handler, const dealii::Mapping<dim> &mapping, const EoMFUN &get_EoM,
       const EoMPFUN &EoM_postprocess = [](const auto &p, const auto &values) { return p; },
-      const double relative_tolerance = 1e-5, const uint max_iter = 100)
+      const double EoM_abs_tol = 1e-5, const uint max_iter = 100)
   {
     if (max_iter == 0) return internal::get_origin(dof_handler, EoM_cell);
 
     if constexpr (dim == 1) {
-      return get_EoM_point_1D(EoM_cell, sol, dof_handler, mapping, get_EoM, EoM_postprocess, relative_tolerance,
-                              max_iter);
+      return get_EoM_point_1D(EoM_cell, sol, dof_handler, mapping, get_EoM, EoM_postprocess, EoM_abs_tol, max_iter);
     } else if constexpr (dim > 1) {
+      return get_EoM_point_ND(EoM_cell, sol, dof_handler, mapping, get_EoM, EoM_postprocess, EoM_abs_tol, max_iter);
+    } else
       throw std::runtime_error("get_EoM_point is not yet implemented for dim > 1. Please set EoM_max_iter = 0.");
-    }
   }
 } // namespace DiFfRG

--- a/DiFfRG/include/DiFfRG/discretization/common/EoM.hh
+++ b/DiFfRG/include/DiFfRG/discretization/common/EoM.hh
@@ -116,7 +116,7 @@ namespace DiFfRG
       typename dealii::DoFHandler<1>::cell_iterator &EoM_cell, const VectorType &sol,
       const dealii::DoFHandler<1> &dof_handler, const dealii::Mapping<1> &mapping, const EoMFUN &get_EoM,
       const EoMPFUN &EoM_postprocess = [](const auto &p, const auto &values) { return p; },
-      const double EoM_abs_tol = 1e-5, const uint max_iter = 100)
+      const double EoM_abs_tol = 1e-8, const uint max_iter = 100)
   {
     constexpr uint dim = 1;
 
@@ -130,7 +130,7 @@ namespace DiFfRG
     Functions::FEFieldFunction<dim, VectorType> fe_function(dof_handler, sol, mapping);
     fe_function.vector_value(origin, values);
     const double EoM_val = get_EoM(origin, values)[0];
-    if (EoM_val >= 0.) {
+    if (EoM_val >= EoM_abs_tol) {
       EoM = origin;
       return EoM;
     }
@@ -280,7 +280,7 @@ namespace DiFfRG
       typename dealii::DoFHandler<dim>::cell_iterator &EoM_cell, const VectorType &sol,
       const dealii::DoFHandler<dim> &dof_handler, const dealii::Mapping<dim> &mapping, const EoMFUN &get_EoM,
       const EoMPFUN &EoM_postprocess = [](const auto &p, const auto &values) { return p; },
-      const double EoM_abs_tol = 1e-5, const uint max_iter = 100)
+      const double EoM_abs_tol = 1e-8, const uint max_iter = 100)
   {
     using namespace dealii;
     using CellIterator = typename dealii::DoFHandler<dim>::cell_iterator;
@@ -292,7 +292,7 @@ namespace DiFfRG
     Functions::FEFieldFunction<dim, VectorType> fe_function(dof_handler, sol, mapping);
     fe_function.vector_value(origin, values);
     const double EoM_val = get_EoM(origin, values)[0];
-    if (EoM_val >= 0.) {
+    if (EoM_val >= EoM_abs_tol) {
       EoM = origin;
       return EoM;
     }
@@ -377,7 +377,7 @@ namespace DiFfRG
       gsl_multiroot_fsolver_set(s, &f, x);
 
       // start the iteration
-      int iter = 0;
+      uint iter = 0;
       int status;
       do {
         iter++;
@@ -386,7 +386,7 @@ namespace DiFfRG
         if (status) break;
 
         status = gsl_multiroot_test_residual(s->f, EoM_abs_tol);
-      } while (status == GSL_CONTINUE && iter < 1000);
+      } while (status == GSL_CONTINUE && iter < max_iter);
 
       EoM_val = 0.;
       for (uint d = 0; d < dim; ++d) {

--- a/DiFfRG/include/DiFfRG/discretization/discretization.hh
+++ b/DiFfRG/include/DiFfRG/discretization/discretization.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-//#include <DiFfRG/discretization/FV/discretization.hh>
+// #include <DiFfRG/discretization/FV/discretization.hh>
 
 #include <DiFfRG/discretization/FEM/cg.hh>
 #include <DiFfRG/discretization/FEM/dg.hh>
@@ -19,4 +19,4 @@
 #include <DiFfRG/discretization/grid/coordinates.hh>
 #include <DiFfRG/discretization/grid/stack_coordinates.hh>
 
-#include <DiFfRG/discretization/common/utils.hh>
+#include <DiFfRG/discretization/common/EoM.hh>

--- a/DiFfRG/include/DiFfRG/discretization/variables/assembler/variables.hh
+++ b/DiFfRG/include/DiFfRG/discretization/variables/assembler/variables.hh
@@ -20,8 +20,8 @@
 
 // DiFfRG
 #include <DiFfRG/common/utils.hh>
+#include <DiFfRG/discretization/common/EoM.hh>
 #include <DiFfRG/discretization/common/abstract_assembler.hh>
-#include <DiFfRG/discretization/common/utils.hh>
 #include <DiFfRG/discretization/data/data_output.hh>
 
 namespace DiFfRG

--- a/DiFfRG/tests/discretization/CMakeLists.txt
+++ b/DiFfRG/tests/discretization/CMakeLists.txt
@@ -19,3 +19,10 @@ setup_test(test_mesh)
 
 add_executable(test_mesh_adaptor test_mesh_adaptor.cc)
 setup_test(test_mesh_adaptor)
+
+# ##############################################################################
+# Test the EoM finding
+# ##############################################################################
+
+add_executable(test_EoM_finding test_EoM_finding.cc)
+setup_test(test_EoM_finding)

--- a/DiFfRG/tests/discretization/test_EoM_finding.cc
+++ b/DiFfRG/tests/discretization/test_EoM_finding.cc
@@ -1,0 +1,321 @@
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include <boilerplate/models.hh>
+
+#include <DiFfRG/common/types.hh>
+#include <DiFfRG/common/utils.hh>
+#include <DiFfRG/discretization/discretization.hh>
+#include <DiFfRG/model/model.hh>
+#include <DiFfRG/physics/physics.hh>
+
+#include <DiFfRG/discretization/common/EoM.hh>
+
+//--------------------------------------------
+// Test logic
+//--------------------------------------------
+
+TEST_CASE("Test 1D EoM finding on CG Constant model", "[discretization][EoM][1d]")
+{
+  using namespace dealii;
+  using namespace DiFfRG;
+
+  constexpr uint dim = 1;
+  using Model = Testing::ModelConstant<dim, dim>;
+  using NumberType = double;
+  using Discretization = CG::Discretization<typename Model::Components, NumberType, RectangularMesh<dim>>;
+  using VectorType = typename Discretization::VectorType;
+  using Assembler = CG::Assembler<Discretization, Model>;
+
+  JSONValue json = json::value(
+      {{"physical", {}},
+       {"integration",
+        {{"x_quadrature_order", 32},
+         {"angle_quadrature_order", 8},
+         {"x0_quadrature_order", 16},
+         {"x0_summands", 8},
+         {"q0_quadrature_order", 16},
+         {"q0_summands", 8},
+         {"x_extent_tolerance", 1e-3},
+         {"x0_extent_tolerance", 1e-3},
+         {"q0_extent_tolerance", 1e-3},
+         {"jacobian_quadrature_factor", 0.5}}},
+       {"discretization",
+        {{"fe_order", GENERATE(1, 2, 3, 4, 5)},
+         {"threads", 8},
+         {"batch_size", 64},
+         {"overintegration", 0},
+         {"output_subdivisions", 2},
+
+         {"EoM_abs_tol", 1e-14},
+         {"EoM_max_iter", 200},
+
+         {"grid", {{"x_grid", "0:0.1:1"}, {"y_grid", "0:0.1:1"}, {"z_grid", "0:0.1:1"}, {"refine", 0}}},
+         {"adaptivity",
+          {{"start_adapt_at", 0.},
+           {"adapt_dt", 1e-1},
+           {"level", 0},
+           {"refine_percent", 1e-1},
+           {"coarsen_percent", 5e-2}}}}},
+       {"timestepping",
+        {{"final_time", 1.},
+         {"output_dt", 1e-1},
+         {"explicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}},
+         {"implicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}}}},
+       {"output", {{"live_plot", false}, {"verbosity", 0}}}});
+
+  Testing::PhysicalParameters p_prm;
+  p_prm.initial_x0[0] = -1.;
+  p_prm.initial_x1[0] = GENERATE(take(5, random(1.1, 10.)));
+
+  const double expected_EoM = -p_prm.initial_x0[0] / p_prm.initial_x1[0];
+
+  try {
+    auto log = spdlog::stdout_color_mt("log");
+    log->set_pattern("log: [%v]");
+    log->info("DiFfRG Application started");
+  } catch (const spdlog::spdlog_ex &e) {
+    // nothing, the logger is already set up
+  }
+
+  // Define the objects needed to run the simulation
+  Model model(p_prm);
+  RectangularMesh<dim> mesh(json);
+  Discretization discretization(mesh, json);
+  Assembler assembler(discretization, model, json);
+
+  // Set up the initial condition
+  FE::FlowingVariables initial_condition(discretization);
+  initial_condition.interpolate(model);
+  const VectorType &src = initial_condition.spatial_data();
+
+  const auto &dof_handler = discretization.get_dof_handler();
+  const auto &mapping = discretization.get_mapping();
+
+  auto EoM_cell = dof_handler.begin_active();
+
+  const double EoM_abs_tol = json.get_double("/discretization/EoM_abs_tol");
+  const uint EoM_max_iter = json.get_uint("/discretization/EoM_max_iter");
+
+  const auto EoM = get_EoM_point(
+      EoM_cell, src, dof_handler, mapping, [&](const auto &p, const auto &values) { return model.EoM(p, values); },
+      [&](const auto &p, const auto &) { return p; }, EoM_abs_tol, EoM_max_iter);
+
+  if (!(std::abs(EoM[0] - expected_EoM) < 1e-6)) {
+    std::cout << "ERROR: " << abs(EoM[0] - expected_EoM) << std::endl;
+    std::cout << "EoM: " << EoM[0] << " expected: " << expected_EoM << std::endl;
+  }
+  REQUIRE(std::abs(EoM[0] - expected_EoM) < 1e-6);
+}
+
+TEST_CASE("Test 2D EoM finding on CG Constant model", "[discretization][EoM][2d]")
+{
+  using namespace dealii;
+  using namespace DiFfRG;
+
+  constexpr uint dim = 2;
+  using Model = Testing::ModelConstant<dim, dim>;
+  using NumberType = double;
+  using Discretization = CG::Discretization<typename Model::Components, NumberType, RectangularMesh<dim>>;
+  using VectorType = typename Discretization::VectorType;
+  using Assembler = CG::Assembler<Discretization, Model>;
+
+  JSONValue json = json::value(
+      {{"physical", {}},
+       {"integration",
+        {{"x_quadrature_order", 32},
+         {"angle_quadrature_order", 8},
+         {"x0_quadrature_order", 16},
+         {"x0_summands", 8},
+         {"q0_quadrature_order", 16},
+         {"q0_summands", 8},
+         {"x_extent_tolerance", 1e-3},
+         {"x0_extent_tolerance", 1e-3},
+         {"q0_extent_tolerance", 1e-3},
+         {"jacobian_quadrature_factor", 0.5}}},
+       {"discretization",
+        {{"fe_order", GENERATE(1, 2, 3, 4, 5)},
+         {"threads", 8},
+         {"batch_size", 64},
+         {"overintegration", 0},
+         {"output_subdivisions", 2},
+
+         {"EoM_abs_tol", 1e-14},
+         {"EoM_max_iter", 200},
+
+         {"grid", {{"x_grid", "0:0.1:1"}, {"y_grid", "0:0.1:1"}, {"z_grid", "0:0.1:1"}, {"refine", 0}}},
+         {"adaptivity",
+          {{"start_adapt_at", 0.},
+           {"adapt_dt", 1e-1},
+           {"level", 0},
+           {"refine_percent", 1e-1},
+           {"coarsen_percent", 5e-2}}}}},
+       {"timestepping",
+        {{"final_time", 1.},
+         {"output_dt", 1e-1},
+         {"explicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}},
+         {"implicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}}}},
+       {"output", {{"live_plot", false}, {"verbosity", 0}}}});
+
+  Testing::PhysicalParameters p_prm;
+  p_prm.initial_x0[0] = -1.;
+  p_prm.initial_x1[0] = GENERATE(take(3, random(1.1, 10.)));
+  p_prm.initial_x0[1] = -1.;
+  p_prm.initial_x1[1] = GENERATE(take(3, random(1.1, 10.)));
+
+  std::array<double, 2> expected_EoM{{}};
+  expected_EoM[0] = -p_prm.initial_x0[0] / p_prm.initial_x1[0];
+  expected_EoM[1] = -p_prm.initial_x0[1] / p_prm.initial_x1[1];
+
+  try {
+    auto log = spdlog::stdout_color_mt("log");
+    log->set_pattern("log: [%v]");
+    log->info("DiFfRG Application started");
+  } catch (const spdlog::spdlog_ex &e) {
+    // nothing, the logger is already set up
+  }
+
+  // Define the objects needed to run the simulation
+  Model model(p_prm);
+  RectangularMesh<dim> mesh(json);
+  Discretization discretization(mesh, json);
+  Assembler assembler(discretization, model, json);
+
+  // Set up the initial condition
+  FE::FlowingVariables initial_condition(discretization);
+  initial_condition.interpolate(model);
+  const VectorType &src = initial_condition.spatial_data();
+
+  const auto &dof_handler = discretization.get_dof_handler();
+  const auto &mapping = discretization.get_mapping();
+
+  auto EoM_cell = dof_handler.begin_active();
+
+  const double EoM_abs_tol = json.get_double("/discretization/EoM_abs_tol");
+  const uint EoM_max_iter = json.get_uint("/discretization/EoM_max_iter");
+
+  const auto EoM = get_EoM_point(
+      EoM_cell, src, dof_handler, mapping, [&](const auto &p, const auto &values) { return model.EoM(p, values); },
+      [&](const auto &p, const auto &) { return p; }, EoM_abs_tol, EoM_max_iter);
+
+  if (!(std::abs(EoM[0] - expected_EoM[0]) < 1e-6) || !(std::abs(EoM[1] - expected_EoM[1]) < 1e-6)) {
+    std::cout << "ERROR: " << sqrt(powr<2>(EoM[0] - expected_EoM[0]) + powr<2>(EoM[1] - expected_EoM[1])) << std::endl;
+    std::cout << "EoM: " << EoM << " expected: (" << expected_EoM[0] << ", " << expected_EoM[1] << ")" << std::endl;
+  }
+  REQUIRE(std::abs(EoM[0] - expected_EoM[0]) < 1e-6);
+  REQUIRE(std::abs(EoM[1] - expected_EoM[1]) < 1e-6);
+}
+
+TEST_CASE("Test 3D EoM finding on CG Constant model", "[discretization][EoM][3d]")
+{
+  using namespace dealii;
+  using namespace DiFfRG;
+
+  constexpr uint dim = 3;
+  using Model = Testing::ModelConstant<dim, dim>;
+  using NumberType = double;
+  using Discretization = CG::Discretization<typename Model::Components, NumberType, RectangularMesh<dim>>;
+  using VectorType = typename Discretization::VectorType;
+  using Assembler = CG::Assembler<Discretization, Model>;
+
+  JSONValue json = json::value(
+      {{"physical", {}},
+       {"integration",
+        {{"x_quadrature_order", 32},
+         {"angle_quadrature_order", 8},
+         {"x0_quadrature_order", 16},
+         {"x0_summands", 8},
+         {"q0_quadrature_order", 16},
+         {"q0_summands", 8},
+         {"x_extent_tolerance", 1e-3},
+         {"x0_extent_tolerance", 1e-3},
+         {"q0_extent_tolerance", 1e-3},
+         {"jacobian_quadrature_factor", 0.5}}},
+       {"discretization",
+        {{"fe_order", GENERATE(1, 2, 3)},
+         {"threads", 8},
+         {"batch_size", 64},
+         {"overintegration", 0},
+         {"output_subdivisions", 2},
+
+         {"EoM_abs_tol", 1e-14},
+         {"EoM_max_iter", 200},
+
+         {"grid", {{"x_grid", "0:0.1:1"}, {"y_grid", "0:0.1:1"}, {"z_grid", "0:0.1:1"}, {"refine", 0}}},
+         {"adaptivity",
+          {{"start_adapt_at", 0.},
+           {"adapt_dt", 1e-1},
+           {"level", 0},
+           {"refine_percent", 1e-1},
+           {"coarsen_percent", 5e-2}}}}},
+       {"timestepping",
+        {{"final_time", 1.},
+         {"output_dt", 1e-1},
+         {"explicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}},
+         {"implicit",
+          {{"dt", 1e-4}, {"minimal_dt", 1e-6}, {"maximal_dt", 1e-1}, {"abs_tol", 1e-14}, {"rel_tol", 1e-8}}}}},
+       {"output", {{"live_plot", false}, {"verbosity", 0}}}});
+
+  Testing::PhysicalParameters p_prm;
+  for (uint d = 0; d < dim; ++d)
+    p_prm.initial_x0[d] = -1.;
+
+  p_prm.initial_x1[0] = GENERATE(take(2, random(1.1, 10.)));
+  p_prm.initial_x1[1] = GENERATE(take(2, random(1.1, 10.)));
+  p_prm.initial_x1[2] = GENERATE(take(2, random(1.1, 10.)));
+
+  dealii::Point<dim> expected_EoM;
+  for (uint d = 0; d < dim; ++d)
+    expected_EoM[d] = -p_prm.initial_x0[d] / p_prm.initial_x1[d];
+
+  try {
+    auto log = spdlog::stdout_color_mt("log");
+    log->set_pattern("log: [%v]");
+    log->info("DiFfRG Application started");
+  } catch (const spdlog::spdlog_ex &e) {
+    // nothing, the logger is already set up
+  }
+
+  // Define the objects needed to run the simulation
+  Model model(p_prm);
+  RectangularMesh<dim> mesh(json);
+  Discretization discretization(mesh, json);
+  Assembler assembler(discretization, model, json);
+
+  // Set up the initial condition
+  FE::FlowingVariables initial_condition(discretization);
+  initial_condition.interpolate(model);
+  const VectorType &src = initial_condition.spatial_data();
+
+  const auto &dof_handler = discretization.get_dof_handler();
+  const auto &mapping = discretization.get_mapping();
+
+  auto EoM_cell = dof_handler.begin_active();
+
+  const double EoM_abs_tol = json.get_double("/discretization/EoM_abs_tol");
+  const uint EoM_max_iter = json.get_uint("/discretization/EoM_max_iter");
+
+  const auto EoM = get_EoM_point(
+      EoM_cell, src, dof_handler, mapping, [&](const auto &p, const auto &values) { return model.EoM(p, values); },
+      [&](const auto &p, const auto &) { return p; }, EoM_abs_tol, EoM_max_iter);
+
+  std::array<double, dim> error{{}};
+  double max_error = 0.;
+  for (uint d = 0; d < dim; ++d) {
+    error[d] = std::abs(EoM[d] - expected_EoM[d]);
+    max_error = std::max(max_error, error[d]);
+  }
+
+  if (max_error >= 1e-5) {
+    std::cout << "ERROR: " << max_error << std::endl;
+    std::cout << "EoM: " << EoM << " expected: " << expected_EoM << std::endl;
+  }
+
+  REQUIRE(max_error < 1e-5);
+}


### PR DESCRIPTION
## Problem:
- The EoM finding until now only supported dim = 1
- There was a bug in the 1D finding, where the bisection could not converge because of faulty starting conditions

## Features:
- The d=1 algorithm has been fixed and leads to correct results
- Added algorithms for d >= 2. These first perform an approximate cell search and then employ a multivariate root finder from the GNU scientific library.
- Increased test coverage: EoM finding in dim=1,2,3 is tested, see `tests/discretization/test_EoM_finding.cc`
- Address #10 by doing the EoM check at the origin with an error tolerance.